### PR TITLE
Add support for Windows by removing the usage of process groups

### DIFF
--- a/http.go
+++ b/http.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-	"syscall"
 )
 
 type service struct {
@@ -145,7 +144,7 @@ func (s *Server) getInfoRefs(_ string, w http.ResponseWriter, r *Request) {
 		fail500(w, context, err)
 		return
 	}
-	defer cleanUpProcessGroup(cmd)
+	defer cleanUpProcess(cmd)
 
 	w.Header().Add("Content-Type", fmt.Sprintf("application/x-%s-advertisement", rpc))
 	w.Header().Add("Cache-Control", "no-cache")
@@ -197,7 +196,7 @@ func (s *Server) postRPC(rpc string, w http.ResponseWriter, r *Request) {
 		fail500(w, context, err)
 		return
 	}
-	defer cleanUpProcessGroup(cmd)
+	defer cleanUpProcess(cmd)
 
 	if _, err := io.Copy(stdin, body); err != nil {
 		fail500(w, context, err)
@@ -243,7 +242,6 @@ func repoExists(p string) bool {
 
 func gitCommand(name string, args ...string) (*exec.Cmd, io.Reader) {
 	cmd := exec.Command(name, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = os.Environ()
 
 	r, _ := cmd.StdoutPipe()

--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"syscall"
 )
 
 var reSlashDedup = regexp.MustCompile(`\/{2,}`)
@@ -26,14 +25,14 @@ func logInfo(context string, message string) {
 	log.Printf("%s: %s\n", context, message)
 }
 
-func cleanUpProcessGroup(cmd *exec.Cmd) {
+func cleanUpProcess(cmd *exec.Cmd) {
 	if cmd == nil {
 		return
 	}
 
 	process := cmd.Process
 	if process != nil && process.Pid > 0 {
-		syscall.Kill(-process.Pid, syscall.SIGTERM)
+		process.Kill()
 	}
 
 	go cmd.Wait()


### PR DESCRIPTION
This unblocks support for Windows, since Windows has a different
construct than process groups and we don't really need process groups
since we don't spawn multiple child/grandchildren processes.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>