### PR TITLE
Simulate EOF at ReadOnly mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	AutoHooks  bool         // Automatically setup git hooks
 	Hooks      *HookScripts // Scripts for hooks/* directory
 	Auth       bool         // Require authentication
+	ReadOnly   bool         // Simulates a user that has read-only access to the repository.
 }
 
 // HookScripts represents all repository server-size git hooks


### PR DESCRIPTION
`ReadOnly` can be configured based on https://github.com/fluxcd/pkg/pull/299.