### PR TITLE
Add option to initialize git repo with a particular branch

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,15 +7,16 @@ import (
 )
 
 type Config struct {
-	KeyDir     string       // Directory for server ssh keys. Only used in SSH strategy.
-	Dir        string       // Directory that contains repositories
-	GitPath    string       // Path to git binary
-	GitUser    string       // User for ssh connections
-	AutoCreate bool         // Automatically create repostories
-	AutoHooks  bool         // Automatically setup git hooks
-	Hooks      *HookScripts // Scripts for hooks/* directory
-	Auth       bool         // Require authentication
-	ReadOnly   bool         // Simulates a user that has read-only access to the repository.
+	KeyDir        string       // Directory for server ssh keys. Only used in SSH strategy.
+	Dir           string       // Directory that contains repositories
+	GitPath       string       // Path to git binary
+	GitUser       string       // User for ssh connections
+	AutoCreate    bool         // Automatically create repostories
+	AutoHooks     bool         // Automatically setup git hooks
+	Hooks         *HookScripts // Scripts for hooks/* directory
+	Auth          bool         // Require authentication
+	ReadOnly      bool         // Simulates a user that has read-only access to the repository.
+	DefaultBranch string       // branch that will be used for initializing the git repository
 }
 
 // HookScripts represents all repository server-size git hooks

--- a/http.go
+++ b/http.go
@@ -228,8 +228,13 @@ func (s *Server) Setup() error {
 func initRepo(name string, config *Config) error {
 	fullPath := path.Join(config.Dir, name)
 
-	if err := exec.Command(config.GitPath, "init", "--bare", fullPath).Run(); err != nil {
-		return err
+	args := []string{"init", "--bare", fullPath}
+	if config.DefaultBranch != "" {
+		args = append(args, "--initial-branch", config.DefaultBranch)
+	}
+	cmd := exec.Command(config.GitPath, args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("err running cmd: %w, output: '%s'", err, out)
 	}
 
 	if config.AutoHooks && config.Hooks != nil {


### PR DESCRIPTION
This pull request adds a DefaultBranch field in the Config that the git repository will be initialized with.
Without this, the repository will be initialized with the default branch in the user's setting.
This can cause unintended side effects, e.g in the source-controller tests that assumes and pushes the `master` branch.
But the repository is initialized to the `main` branch per-user settings. Cloning the repository without specifying a branch fails.
